### PR TITLE
Possibilitando a visualização de faturas mesmo após a destruição do Billable. Finally Closes #609

### DIFF
--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -143,7 +143,7 @@ class EnvironmentsController < BaseController
   # DELETE /environments/1
   # DELETE /environments/1.xml
   def destroy
-    @environment.destroy
+    @environment.audit_billable_and_destroy
 
     respond_to do |format|
       format.html { redirect_to(teach_index_url) }

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -13,7 +13,7 @@ class InvoicesController < BaseController
 
     if @plan
       @invoices = @plan.invoices
-      @quota = @plan.billable.quota if @plan.billable.quota
+      @quota = @plan.billable.quota if @plan.billable
     elsif @partner
       @invoices = @partner.invoices
       if params.fetch(:year, false)

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -30,7 +30,7 @@ class Environment < ActiveRecord::Base
     :conditions => [ "user_environment_associations.role = ?", 2 ]
 
   has_one :partner, :through => :partner_environment_association
-  has_one :partner_environment_association, :dependent => :destroy
+  has_one :partner_environment_association
   has_one :quota, :dependent => :destroy, :as => :billable
 
   attr_protected :owner, :published

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -16,8 +16,9 @@ class Invoice < ActiveRecord::Base
   scope :of_period, lambda { |period|
     where(:period_end => period)
   }
-  scope :of_billable, lambda { |billable|
-    where(:plan_id => billable.plans.collect(&:id).flatten)
+  # Feito desta forma, pois o billable pode ter sido destruído
+  scope :of_billable, lambda { |billable_id, billable_type|
+    where(:plan_id => Plan.where(:billable_id => billable_id, :billable_type => billable_type))
   }
 
   attr_protected :state

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -8,7 +8,7 @@ class License < ActiveRecord::Base
   # Retorna todas as licenças que estão em uso
   scope :in_use, where(:period_end => nil)
   scope :of_course, lambda { |course|
-    where(:course_id => course.id)
+    where(:course_id => course)
   }
   # Retorna todas as licenças consideradas pagáveis
   scope :payable, where(:role => Role[:member])

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -1,9 +1,9 @@
 class Partner < ActiveRecord::Base
-  has_many :partner_environment_associations, :order => "partner_environment_associations.created_at DESC"
+  has_many :partner_environment_associations, :order => "partner_environment_associations.created_at DESC", :dependent => :destroy
   has_many :environments, :through => :partner_environment_associations,
     :order => "partner_environment_associations.created_at DESC"
   has_many :users, :through => :partner_user_associations
-  has_many :partner_user_associations
+  has_many :partner_user_associations, :dependent => :destroy
 
   validates_presence_of :name, :email, :cnpj, :address
 
@@ -43,8 +43,12 @@ class Partner < ActiveRecord::Base
   end
 
   # Returns all environments' invoices
+  # Feito desta forma, pois o environment pode ter sido destruído
   def invoices
-    plans_ids = self.environments.collect { |e| e.plans.collect(&:id) }
+    plans_ids = self.partner_environment_associations.collect do |assoc|
+      Plan.where(:billable_id => assoc.environment_id,
+                 :billable_type => "Environment").collect(&:id)
+    end
     Invoice.where(:plan_id => plans_ids.flatten)
   end
 

--- a/app/models/partner_environment_association.rb
+++ b/app/models/partner_environment_association.rb
@@ -11,4 +11,11 @@ class PartnerEnvironmentAssociation < ActiveRecord::Base
     self.cnpj =~ /(\d{2})\.?(\d{3})\.?(\d{3})\/?(\d{4})-?(\d{2})/
     "#{$1}.#{$2}.#{$3}/#{$4}-#{$5}"
   end
+
+  # Retorna o plano de um environment destruído
+  def plan_of_dead_environment
+    Plan.where(:billable_id => self.environment_id,
+               :billable_type => "Environment").
+               order("created_at DESC").limit(1).first
+  end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,7 +1,7 @@
 class Plan < ActiveRecord::Base
   include AASM
 
-  serialize :billable_audit, Course
+  serialize :billable_audit
 
   belongs_to :billable, :polymorphic => true
   belongs_to :user
@@ -50,8 +50,10 @@ class Plan < ActiveRecord::Base
 
   # Serializa billable associado e salva com propósito de auditoria
   def audit_billable!
-    self.billable_audit = self.billable
-    save!
+    options = Hash.new
+    options[:include] = [:courses, :partner_environment_association] if self.billable.is_a? Environment
+    self.billable_audit = self.billable.serializable_hash(options)
+    self.save!
   end
 
   def invoice

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -225,7 +225,14 @@ class User < ActiveRecord::Base
     when 'User'
       entity == self
     when 'Plan', 'PackagePlan', 'LicensedPlan'
-      entity.user == self || self.can_manage?(entity.billable)
+      entity.user == self || self.can_manage?(entity.billable) ||
+        # Caso em que billable foi destruído
+        self.can_manage?(
+          # Não levanta RecordNotFound
+          Partner.where( :id => entity.billable_audit.
+                        try(:[], :partner_environment_association).
+                        try(:[],"partner_id")).first
+      )
     when 'Invoice', 'LicensedInvoice', 'PackageInvoice'
       self.can_manage?(entity.plan)
     when 'Myfile'

--- a/app/views/invoices/_billable_details.html.erb
+++ b/app/views/invoices/_billable_details.html.erb
@@ -1,9 +1,15 @@
 <%# Detalhes do billable
-  Params: billable (Environment) %>
-<% invoices.of_billable(billable).each do |invoice| %>
+  Params: partner_environment_association %>
+<% invoices.of_billable(partner_environment_association.environment_id, "Environment").each do |invoice| %>
   <div class="billable-infos">
-    <h3 class="name"><%= billable.name %></h3>
-    <span class="created-by">Criado por <%= billable.owner ? billable.owner.display_name : "Usuário removido" %></span>
+    <% if partner_environment_association.environment %>
+      <h3 class="name"><%= partner_environment_association.environment.name %></h3>
+      <span class="created-by">Criado por <%= partner_environment_association.environment.owner.try(:display_name) || "Usuário removido" %></span>
+    <% else %>
+      <% environment = partner_environment_association.plan_of_dead_environment.billable_audit %>
+      <h3 class="name"><%= environment["name"] %></h3>
+      <span class="created-by">Criado por <%= environment["owner"].try(:display_name) || "Usuário removido" %></span>
+    <% end %>
 
     <%= render "invoices/#{invoice.plan.class.to_s.underscore}_details", :invoice => invoice %>
   </div>

--- a/app/views/invoices/_client.html.erb
+++ b/app/views/invoices/_client.html.erb
@@ -1,9 +1,20 @@
 <%# Cliente da fatura
-    Params: client (Partner || Environment), period (Date Range)%>
+  Params: client (Partner || Environment || Hash (dead_environment)),
+  period (Date Range)%>
 <div class="client-infos">
-  <h2 class="name"><%= client.name %></h2>
-  <span class="cnpj info"><strong>CNPJ:</strong> <%= client.is_a?(Partner) ? client.formatted_cnpj : client.partner_environment_association.formatted_cnpj %></span>
-  <span class="address info"><strong>Endereço:</strong> <%= client.is_a?(Partner) ? client.address : client.partner_environment_association.address %></span>
+  <h2 class="name"><%= client.is_a?(Hash) ? client["name"] : client.name %></h2>
+  <% if client.is_a? Partner %>
+    <span class="cnpj info"><strong>CNPJ:</strong><%= client.formatted_cnpj %></span>
+    <span class="address info"><strong>Endereço:</strong> <%= client.address %></span>
+  <% else %>
+    <% if client.is_a? Environment %>
+      <span class="cnpj info"><strong>CNPJ:</strong><%= client.partner_environment_association.formatted_cnpj %></span>
+      <span class="address info"><strong>Endereço:</strong> <%= client.partner_environment_association.address %></span>
+    <% else %>
+      <span class="cnpj info"><strong>CNPJ:</strong><%= client[:partner_environment_association]["cnpj"] %></span>
+      <span class="address info"><strong>Endereço:</strong> <%= client[:partner_environment_association]["address"] %></span>
+    <% end %>
+  <% end %>
   <span class="emission info"><strong>Emissão:</strong> <%= l Date.today %></span>
   <% unless period.nil? %>
     <span class="period"><strong>Período:</strong> <%= l period.begin %> a <%= l period.end %></span>

--- a/app/views/invoices/_course_details.html.erb
+++ b/app/views/invoices/_course_details.html.erb
@@ -1,7 +1,7 @@
 <%# Detalhes do curso em relação ao invoice
     Params: course, invoice %>
 <li class="item">
-  <h4 class="course-name"><%= course.name %></h4>
+  <h4 class="course-name"><%= course.is_a?(Course) ? course.name : course["name"] %></h4>
   <table class="common spaced">
     <thead>
       <th>#</th>
@@ -12,7 +12,7 @@
       <th>Papel no curso</th>
     </thead>
     <tbody>
-      <%= render :partial => "licenses/item", :collection => invoice.licenses.of_course(course) %>
+      <%= render :partial => "licenses/item", :collection => course.is_a?(Course) ? invoice.licenses.of_course(course) : invoice.licenses.of_course(course["id"]) %>
     </tbody>
   </table>
 </li>

--- a/app/views/invoices/_licensed_plan_details.html.erb
+++ b/app/views/invoices/_licensed_plan_details.html.erb
@@ -5,10 +5,10 @@
     <h3 class="plan-name"><%= invoice.plan.name %></h3>
     <span class="infos">
       <strong>Licença:</strong> <span class="price"><%= number_to_currency invoice.plan.price %>;</span> <strong>capacidade de armazenamento:</strong> <span class="storage-limit"><%= number_to_human_size(invoice.plan.video_storage_limit + invoice.plan.file_storage_limit, :precision => 0) %>;</span> <strong>usuários inscritos:</strong> <span class="qtt-members"><%= invoice.licenses.count %>;</span> <strong>licenças pagáveis:</strong> <span class="qtt-payable-licenses"><%= invoice.licenses.payable.count %></span></span>
-    <span class="plan-period"><strong>Período:</strong><%= l invoice.period_start %> a <%= l invoice.period_end %></span>
+    <span class="plan-period"><strong>Período:</strong> <%= l invoice.period_start %> a <%= l invoice.period_end %></span>
   </div>
   <ul class="courses">
-    <%= render :partial => "invoices/course_details", :collection => invoice.plan.billable.courses, :as => :course, :locals => { :invoice => invoice } %>
+    <%= render :partial => "invoices/course_details", :collection => invoice.plan.billable.try(:courses) || invoice.plan.billable_audit.try(:[], :courses), :as => :course, :locals => { :invoice => invoice } %>
   </ul>
 
   <span class="total">

--- a/app/views/invoices/_package_plan_details.html.erb
+++ b/app/views/invoices/_package_plan_details.html.erb
@@ -6,7 +6,7 @@
     <h3 class="plan-name"><%= invoice.plan.name %></h3>
     <span class="infos">
       <strong>Preço:</strong> <span class="price"><%= number_to_currency invoice.plan.price %>;</span> <strong>capacidade de armazenamento:</strong> <span class="storage-limit"><%= number_to_human_size(invoice.plan.video_storage_limit + invoice.plan.file_storage_limit, :precision => 0) %></span>
-    <span class="plan-period"><strong>Período:</strong><%= l invoice.period_start %> a <%= l invoice.period_end %></span>
+    <span class="plan-period"><strong>Período:</strong> <%= l invoice.period_start %> a <%= l invoice.period_end %></span>
   </div>
 
   <span class="total">

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -5,23 +5,27 @@
     <%= tabs :users do %>
     <div class="call">
       <span class="billable">
-      <% if @plan.billable.is_a? Environment %>
-        <%= link_to @plan.billable.name, @plan.billable %>
-      <% else %>
-        <%= link_to @plan.billable.name,
-          environment_course_path(@plan.billable.environment, @plan.billable) %>
-      <% end %>
+        <% if @plan.billable.is_a? Environment %>
+          <%= link_to @plan.billable.name, @plan.billable %>
+        <% elsif @plan.billable.is_a? Course %>
+          <%= link_to @plan.billable.name,
+            environment_course_path(@plan.billable.environment, @plan.billable) %>
+        <% elsif @plan.billable_audit %>
+          <%= content_tag :span, @plan.billable_audit["name"] %>
+        <% end %>
       </span>
       <span class="name"><%= @plan.name %></span>
     </div>
-    <div class="plan-use">
-      <%= render :partial => "invoices/quotas",
-        :locals => { :quota_file => @plan.billable.percentage_quota_file,
-                     :plan => @plan,
-                     :quota_multimedia => @plan.billable.percentage_quota_multimedia,
-                     :quota_members => @plan.billable.percentage_quota_members,
-                     :quota => @quota } %>
-    </div>
+    <% if @quota %>
+      <div class="plan-use">
+        <%= render :partial => "invoices/quotas",
+          :locals => { :quota_file => @plan.billable.percentage_quota_file,
+                       :plan => @plan,
+                       :quota_multimedia => @plan.billable.percentage_quota_multimedia,
+                       :quota_members => @plan.billable.percentage_quota_members,
+                       :quota => @quota } %>
+      </div>
+    <% end %>
     <table class="common spaced">
       <thead>
         <tr>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -2,11 +2,15 @@
 <div id="invoice-show">
   <%= render 'invoices/report_header' %>
 
-  <%= render 'invoices/client', :client => @plan.billable, :period => @invoice.period_start..@invoice.period_end %>
+  <%= render 'invoices/client', :client => @plan.billable || @plan.billable_audit, :period => @invoice.period_start..@invoice.period_end %>
 
   <div class="billable-infos">
-    <h3 class="name"><%= @plan.billable.name %></h3>
-    <span class="created-by">Criado por <%= @plan.billable.owner ? @plan.billable.owner.display_name : "Usuário removido" %></span>
+    <h3 class="name"><%= @plan.billable.try(:name) || @plan.billable_audit.try(:[], "name") %></h3>
+    <% if @plan.billable %>
+      <span class="created-by">Criado por <%=  @plan.billable.owner.try(:display_name) || "Usuário removido" %></span>
+    <% else %>
+      <span class="created-by">Criado por <%= @plan.billable_audit["owner"].try(:display_name) || "Usuário removido" %></span>
+    <% end %>
 
     <%= render "invoices/#{@invoice.plan.class.to_s.underscore}_details", :invoice => @invoice %>
   </div>

--- a/app/views/partner_environment_associations/_item.html.erb
+++ b/app/views/partner_environment_associations/_item.html.erb
@@ -1,11 +1,29 @@
+<% if item.environment %>
 <li class="clearfix">
   <%= image_tag item.environment.avatar(:thumb_32), :size => "32x32", :class => "avatar" %>
   <div class="environment-info">
     <%= link_to item.environment.name, environment_path(item.environment), :class => "environment-name" %>
     <span class="date">Criado há <%= time_ago_in_words(item.created_at) %> por</span>
-    <%= link_to item.environment.owner.display_name, user_path(item.environment.owner), :class=> "owner" %>
+    <%= link_to_if item.environment.owner, item.environment.owner.try(:display_name), user_path(item.environment.owner), :class=> "owner" do
+      content_tag(:span, "Usuário removido", :class => "owner")
+    end %>
   </div>
   <% if item.environment.plan %>
     <%= link_to "ver faturas", partner_client_plan_invoices_path(item.partner, item, item.environment.plan), :class => 'see-invoices' %>
   <% end %>
 </li>
+<% else %>
+  <% environment = item.plan_of_dead_environment.billable_audit %>
+  <% if environment %>
+    <li class="clearfix">
+      <%= image_tag 'new/missing_environments_thumb_32.png', :size => "32x32", :class => "avatar" %>
+      <div class="environment-info">
+        <%= content_tag :span, environment["name"], :class => "environment-name" %>
+        <span class="date">Criado há <%= time_ago_in_words(item.created_at) %> por</span>
+        <%= content_tag :span, environment["owner"].try(:display_name) || "Usuário removido", :class => "owner" %>
+      </div>
+      <%= link_to "ver faturas", partner_client_plan_invoices_path(item.partner, item, item.plan_of_dead_environment), :class => 'see-invoices' %>
+      <span class="removed-environment">Ambiente removido</span>
+    </li>
+  <% end %>
+<% end %>

--- a/app/views/partner_environment_associations/invoices/index.html.erb
+++ b/app/views/partner_environment_associations/invoices/index.html.erb
@@ -8,21 +8,25 @@
         <span class="billable">
           <% if @plan.billable.is_a? Environment %>
             <%= link_to @plan.billable.name, @plan.billable %>
-          <% else %>
+          <% elsif @plan.billable.is_a? Course %>
             <%= link_to @plan.billable.name,
               environment_course_path(@plan.billable.environment, @plan.billable) %>
+          <% elsif @plan.billable_audit %>
+            <%= content_tag :span, @plan.billable_audit["name"] %>
           <% end %>
         </span>
         <span class="name"><%= @plan.name %></span>
       </div>
-      <div class="plan-use">
-        <%= render :partial => "invoices/quotas",
-          :locals => { :quota_file => @plan.billable.percentage_quota_file,
-                       :plan => @plan,
-                       :quota_multimedia => @plan.billable.percentage_quota_multimedia,
-                       :quota_members => @plan.billable.percentage_quota_members,
-                       :quota => @quota } %>
-      </div>
+      <% if @quota %>
+        <div class="plan-use">
+          <%= render :partial => "invoices/quotas",
+            :locals => { :quota_file => @plan.billable.percentage_quota_file,
+                         :plan => @plan,
+                         :quota_multimedia => @plan.billable.percentage_quota_multimedia,
+                         :quota_members => @plan.billable.percentage_quota_members,
+                         :quota => @quota } %>
+        </div>
+    <% end %>
       <table class="common spaced">
         <thead>
           <tr>

--- a/app/views/partners/invoices/index.html.erb
+++ b/app/views/partners/invoices/index.html.erb
@@ -4,7 +4,7 @@
 
   <%= render 'invoices/client', :client => @partner, :period => @reference_period %>
 
-  <%= render :partial => 'invoices/billable_details', :collection => @partner.environments, :as => :billable, :locals => { :invoices => @invoices } %>
+  <%= render :partial => 'invoices/billable_details', :collection => @partner.partner_environment_associations, :as => :partner_environment_association, :locals => { :invoices => @invoices } %>
 
   <span class="total-partner">
     Total final: <strong><%= number_to_currency total_amount_of(@invoices) %></strong>

--- a/app/views/plans/_item.html.erb
+++ b/app/views/plans/_item.html.erb
@@ -9,23 +9,15 @@
           :class => "billable" %>
       <% end %>
     <% else %>
-      <span class="name"><%= item.billable_audit.try(:name) || "Sem informações" %> (removido)</span>
+      <span class="name"><%= item.billable_audit.try(:[], "name") || "Sem informações" %> (removido)</span>
     <% end %>
   </td>
   <td>
-    <% if item.billable %>
-      <%=
-        link_to item.name, plan_invoices_path(item),
-          :class => "name"
-        %>
-      <% if item.pending_payment? %>
-        <span class="info">Pagamento pendente</span>
-      <% else %>
-        <span class="info">Sem pendências</span>
-      <% end %>
-
+    <%= link_to item.name, plan_invoices_path(item), :class => "name" %>
+    <% if item.pending_payment? %>
+      <span class="info">Pagamento pendente</span>
     <% else %>
-      <span class="name"><%= item.name %></span>
+      <span class="info">Sem pendências</span>
     <% end %>
   </td>
   <td>

--- a/lib/acts_as_billable.rb
+++ b/lib/acts_as_billable.rb
@@ -38,5 +38,10 @@ module ActsAsBillable
         ( self.users.count * 100.0 )/ self.plan.members_limit
       end
     end
+
+    def audit_billable_and_destroy
+      plan.audit_billable! if self.plan
+      self.destroy
+    end
   end
 end

--- a/public/stylesheets/new-style.css
+++ b/public/stylesheets/new-style.css
@@ -7124,6 +7124,14 @@ a.link-loading:hover,  /* para sobrepor a precedência de input.important */
   display: block;
   float: right;
 }
+
+#partner-environments-list li .removed-environment {
+  font-size: 11px;
+  float: right;
+  margin-right: 10px;
+  color: rgb(255, 109, 109);
+}
+
 #partner-admins-list {
   margin-bottom: 40px;
 }

--- a/spec/controllers/environments_controller_spec.rb
+++ b/spec/controllers/environments_controller_spec.rb
@@ -260,5 +260,18 @@ describe EnvironmentsController do
         end
       end
     end
+
+    context "POST destroy" do
+      before do
+        @plan = Factory(:active_package_plan, :billable => @environment)
+        @post_params = { :locale => "pt-BR" }
+        @post_params[:id] = @environment.path
+        post :destroy, @post_params
+      end
+
+      it "should store billable" do
+        @plan.reload.billable_audit.should_not be_nil
+      end
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -689,6 +689,11 @@ describe Ability do
             @ability.should be_able_to(:read, @licensed_plan)
           end
 
+          it "can read partner licensed_plans of dead billable" do
+            @licensed_plan.billable.audit_billable_and_destroy
+            @ability.should be_able_to(:read, @licensed_plan.reload)
+          end
+
           it "can manage partner licensed_plans" do
             @ability.should be_able_to(:manage, @licensed_plan)
           end
@@ -719,6 +724,11 @@ describe Ability do
           it "can NOT pay a non pending invoice" do
             @invoice.pay!
             @ability.should_not be_able_to(:pay, @invoice.reload)
+          end
+
+          it "can maange partner licensed_plans of dead billable" do
+            @licensed_plan.billable.audit_billable_and_destroy
+            @ability.should be_able_to(:manage, @licensed_plan)
           end
         end
       end

--- a/spec/models/course_observer_spec.rb
+++ b/spec/models/course_observer_spec.rb
@@ -21,7 +21,8 @@ describe CourseObserver do
 
         ActiveRecord::Observer.with_observers :course_observer do
           subject.billable.destroy
-          subject.reload.billable_audit.should == course
+          subject.reload.billable_audit["name"].should == course.name
+          subject.reload.billable_audit["path"].should == course.path
         end
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -800,5 +800,27 @@ describe Course do
         end
       end
     end
+
+    context "when destroying" do
+      let(:subject) { Factory(:course) }
+      context "with an associated plan" do
+        it "should persist environment attributes" do
+          subject.plans = []
+          plan = Factory(:active_package_plan, :billable => subject)
+
+          subject.audit_billable_and_destroy
+          plan.reload.billable_audit["name"].should == subject.name
+          plan.reload.billable_audit["path"].should == subject.path
+        end
+      end
+
+      context "withdout an associated plan" do
+        it "should only destroy itself" do
+          expect {
+            subject.audit_billable_and_destroy
+          }.should_not raise_error
+        end
+      end
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -62,7 +62,7 @@ describe Invoice do
         Factory(:invoice, :plan => plans[1])
       end
 
-      Invoice.of_billable(plans[0].billable).to_set.
+      Invoice.of_billable(plans[0].billable, plans[0].billable.class).to_set.
         should == invoices.to_set
     end
   end

--- a/spec/models/partner_environment_association_spec.rb
+++ b/spec/models/partner_environment_association_spec.rb
@@ -13,4 +13,17 @@ describe PartnerEnvironmentAssociation do
     subject.cnpj = "12123123123412"
     subject.formatted_cnpj.should == "12.123.123/1234-12"
   end
+
+  context "when destroyed billable" do
+    before do
+      @plan = Factory(:active_package_plan, :billable => subject.environment)
+      subject.environment.audit_billable_and_destroy
+    end
+
+    it "should return the plan" do
+      subject.reload
+      subject.environment.should be_nil
+      subject.plan_of_dead_environment.should == @plan
+    end
+  end
 end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -6,6 +6,8 @@ describe Partner do
   it { should validate_presence_of :name }
   it { should validate_presence_of :email }
   it { should validate_presence_of :address }
+  it { should have_many(:partner_environment_associations).dependent(:destroy) }
+  it { should have_many(:partner_user_associations).dependent(:destroy) }
   it { should have_many(:environments).through(:partner_environment_associations) }
   it { should have_many(:users).through(:partner_user_associations) }
 

--- a/spec/models/user_course_invitation_spec.rb
+++ b/spec/models/user_course_invitation_spec.rb
@@ -91,8 +91,9 @@ describe UserCourseInvitation do
       end
 
       it "do NOT accept if it does not have a user" do
-        subject.accept!
-        subject.should_not be_approved
+        expect {
+          subject.accept!
+        }.to raise_error(AASM::InvalidTransition)
       end
 
       it "creates a user course association with state 'invited'" do

--- a/spec/support/billable_spec.rb
+++ b/spec/support/billable_spec.rb
@@ -12,6 +12,13 @@ shared_examples_for "a billable" do
     subject.plan.should == plan2
   end
 
+  it "should stores itself ond plan and self destroy" do
+    Factory(:plan, :billable => subject)
+    subject.should_receive(:destroy)
+    subject.audit_billable_and_destroy
+    subject.plan.billable_audit.should_not be_nil
+  end
+
   context "Quotas" do
     it "retrieve a percentage of quota file" do
       billable.quota.files = 512


### PR DESCRIPTION
Guarda o billable destruído (serializado) na coluna billable_audit de Plan. Caso o billable seja um Environment, também guarda seus cursos.

PartnerEnvironmentAssociation não é mais dependente da destruição de Environment, portanto os dados para fatura (CNPJ e Endereço) são mantidos na base desta forma.

Nos casos de ambiente destruído, pode visualizar a fatura quem puder administrar o parceiro responsável. No caso de curso (sem participação do parceiro), quem pode visualizar a fatura é o criador do curso.

Importante!
A partir deste commit, para destruir um ambiente, deve-se chamar `audit_billable_and_destroy`, ao invés de `destroy`, para que ele guarde suas informações (cursos incluídos) antes.
