### PR TITLE
Ao passar o LicensedInvoice para pending, setando o period_end apenas das licenças que não possuem period_end. Closes #650

### DIFF
--- a/app/models/licensed_invoice.rb
+++ b/app/models/licensed_invoice.rb
@@ -101,6 +101,6 @@ class LicensedInvoice < Invoice
   # Atualiza as licenças do invoice para terem um period_end
   def set_licenses_period_end
     License.update_all(["period_end = ? ", self.period_end],
-                       ["id IN (?)", self.licenses.collect(&:id)])
+                       ["id IN (?)", self.licenses.in_use.collect(&:id)])
   end
 end

--- a/spec/models/licensed_invoice_spec.rb
+++ b/spec/models/licensed_invoice_spec.rb
@@ -306,8 +306,10 @@ describe LicensedInvoice do
         Factory(:license, :invoice => @invoice1, :period_end => nil,
                 :course => course)
       end
-      (1..20).collect { Factory(:license, :invoice => @invoice1,
-                                :course => course) }
+      @not_in_use_licenses = (1..20).collect do
+        Factory(:license, :invoice => @invoice1,
+                :course => course)
+      end
       (1..20).collect { Factory(:license, :invoice => @invoice2,
                                 :course => course) }
 
@@ -359,6 +361,12 @@ describe LicensedInvoice do
         invoice = @plan1.invoices.first
         invoice.licenses.in_use.should be_empty
         @in_use_licenses.first.reload.period_end.should == invoice.period_end
+      end
+
+      it "should NOT update period_end of licenses with period end" do
+        invoice = @plan1.invoices.first
+        @not_in_use_licenses.first.reload.period_end.should_not ==
+          invoice.period_end
       end
     end
 


### PR DESCRIPTION
As licenças que já possuem period_end são referentes usuários que saíram do curso antes do fechamento do mês.
