### PR TITLE
Refatora o modo como é atribuído o login ao usuário criado pelo FB-conne...

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -36,7 +36,7 @@ class Authentication < ActiveRecord::Base
     if !login
       # Usuário não possui um nickname no Facebook.
       # Gera login a partir de nome e sobrenome.
-      login = info_hash[:first_name] + info_hash[:last_name]
+      login = "#{info_hash[:first_name]}#{info_hash[:last_name]}"
       login = login.delete(' ').parameterize
     end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,7 +74,7 @@ Redu::Application.configure do
   OmniAuth.config.mock_auth[:facebook] = {
     :provider => 'facebook',
     :uid => '123545',
-    :info => {'email' => 'user@example.com',
+    :info => {:email => 'user@example.com',
       :first_name => 'Some',
       :last_name => 'Userville'
     }


### PR DESCRIPTION
...ct numa tentativa de sanar o erro e corrige o mockup do Omniauth (que fazia com que os testes falhassem).
