### PR TITLE
Mostrando gráfico no Firefox

### DIFF
--- a/public/javascripts/graph_form.js
+++ b/public/javascripts/graph_form.js
@@ -17,8 +17,8 @@ var graphForm = function () {
   };
 
   var validate_date = function () {
-    var st = Date.parse(time_selected("start"));
-    var en = Date.parse(time_selected("end"));
+    var st = Date.parse(time_selected("start").replace(/\-/ig, '/'));
+    var en = Date.parse(time_selected("end").replace(/\-/ig, '/'));
 
     return st < en;
   }

--- a/public/stylesheets/new-style.css
+++ b/public/stylesheets/new-style.css
@@ -7893,6 +7893,11 @@ a.link-loading:hover,  /* para sobrepor a precedência de input.important */
   padding: 0px;
 }
 
+#lecture-participation-chart{
+  overflow: hidden;
+  clear: left;
+}
+
 /*-- #graph-form é o .concave-form do gráfico --*/
 #graph-form .inline {
   float: left;


### PR DESCRIPTION
Alteração da comparação de datas via javascript.
Houve um quebra de layout quando o gráfico apareceu no firefox, por isso a adição de uma regra ao css.
