### PR TITLE
Issue 800

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -21,9 +21,7 @@ class AuthenticationsController < ApplicationController
         # Existe conta no Redu com o e-mail associado à conta do FB.
         user.authentications.create!(:provider => auth[:provider],
                                      :uid => auth[:uid])
-        unless user.activated_at
-          user.activated_at = Time.now
-        end
+        user.activated_at ||= Time.now
         flash[:notice] = t :facebook_connect_account_association
       else
         # Não existe conta do Redu associada ao e-mail do usuário no FB. 

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -58,13 +58,13 @@ describe AuthenticationsController do
             @user = Factory.create(:user)
             @user.update_attributes(:activated_at => nil)
             request.env['omniauth.auth'][:info][:email] = @user.email
+            @provider = request.env['omniauth.auth'][:provider]
+            @uid = request.env['omniauth.auth'][:uid]
           end
 
           it "should activate account when user connects with Facebook" do
             get :create, :locale => 'pt-BR'
-            provider = request.env['omniauth.auth'][:provider]
-            uid = request.env['omniauth.auth'][:uid]
-            @created_auth = Authentication.find_by_provider_and_uid(provider, uid)
+            @created_auth = Authentication.find_by_provider_and_uid(@provider, @uid)
             user = @created_auth.user
             user.activated_at.should_not be_nil
           end
@@ -73,9 +73,7 @@ describe AuthenticationsController do
             before do
               @user.update_attributes(:created_at => 2.months.ago)
               get :create, :locale => 'pt-BR'
-              provider = request.env['omniauth.auth'][:provider]
-              uid = request.env['omniauth.auth'][:uid]
-              @created_auth = Authentication.find_by_provider_and_uid(provider, uid)
+              @created_auth = Authentication.find_by_provider_and_uid(@provider, @uid)
             end
 
             it "should activate account when user connects with Facebook" do


### PR DESCRIPTION
Ativa contas de usuários que se conectam pela primeira vez com o Facebook connect. Para ativar a conta daqueles que já usaram o FB-connect, deve-se rodar [este](https://gist.github.com/34c4690c641220a3f946) script.
