### PR TITLE
Solução para a requisição replicada na home. Adicionei o SRC para uma im...

### DIFF
--- a/app/views/statuses/_template_preview.html.erb
+++ b/app/views/statuses/_template_preview.html.erb
@@ -6,7 +6,7 @@
       <!-- thumbnail -->
       {{ if(obj.first_thumb) { }}
       <div class="thumbnail">
-        <img id="thumbnail-0" class="preview-link" src="#" />
+        <%= image_tag "/new/overlay-85.png", :id => "thumbnail-0", :class => "preview-link" %>
         <ul class="buttons-thumbnail">
           <!-- multiplos thumbanails -->
           {{ if (obj.thumbnail_url instanceof Array) { }}


### PR DESCRIPTION
...agem que é carregada em todas as páginas e é amenor de todas. O problema foi reportado no issue #887 e é explicado com detalhes em: http://www.nczonline.net/blog/2009/11/30/empty-image-src-can-destroy-your-site/

Closes #887.
