### PR TITLE
Removendo inconsistência do relatório de professores

### DIFF
--- a/app/visualizations/teacher_participation.rb
+++ b/app/visualizations/teacher_participation.rb
@@ -56,8 +56,8 @@ class TeacherParticipation
     @statuses = Status.from_hierarchy(@course)
     @total_posts = @statuses.activity_by_user(@user_id)
 
-    lectures = Lecture.by_subjects(@subjects_space)
-    @statusable_ids = @total_posts.by_statusable("Lecture", lectures)
+    @lectures = Lecture.by_subjects(@subjects_space)
+    @statusable_ids = @total_posts.by_statusable("Lecture", @lectures)
     @statusable_ids += @total_posts.by_statusable("Space", @spaces)
 
     @total_posts = @total_posts.by_id(@statusable_ids)
@@ -67,7 +67,12 @@ class TeacherParticipation
   # do professor naquelas disciplinas + aulas
   def answers_by_space
     helps_activities = @statuses.helps_and_activities
-    @total_helps_and_activities = helps_activities.by_id(@statusable_ids)
+
+    # Respostas à qualquer post da disciplina + aulas
+    statusable_ids = helps_activities.by_statusable("Lecture", @lectures)
+    statusable_ids += helps_activities.by_statusable("Space", @spaces)
+
+    @total_helps_and_activities = helps_activities.by_id(statusable_ids)
     @answers_ids = @total_helps_and_activities.inject([]) do |acc, help|
       acc.concat(help.answers_ids(@user_id))
     end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -5,7 +5,7 @@ describe Status do
   it { should have_many(:users).through(:status_user_associations) }
   it { should have_many(:status_user_associations).dependent(:destroy) }
   it { should have_many(:status_resources).dependent(:destroy) }
-  it { should have_many(:answers).dependent(:destroy) }  
+  it { should have_many(:answers).dependent(:destroy) }
 
   context "scopes" do
     before do
@@ -100,8 +100,9 @@ describe Status do
     context "filtering" do
       before do
         @user = Factory(:user)
-        @activity_statuses = (1..2).collect { Factory(:activity, :user => @user,
-                                                     :statusable => @spaces.first) }
+        @activity_statuses = (1..2).collect {
+          Factory(:activity, :user => @user,
+                  :statusable => @spaces.first) }
         @activity_statuses << Factory(:activity, :statusable => @spaces.first)
         @activity_statuses << Factory(:activity, :statusable => @spaces.first)
       end

--- a/spec/visualizations/teacher_participation_spec.rb
+++ b/spec/visualizations/teacher_participation_spec.rb
@@ -11,29 +11,34 @@ describe TeacherParticipation do
     @lecture_statuses = []
     @ans = []
 
+    @ini = "2012-02-15".to_date
+    @end = "2012-02-16".to_date
+
     2.times.collect  do
       s = Factory(:space, :course => @course)
       su = Factory(:subject, :space => s,
                    :owner => @owner, :finalized => true)
       l = Factory(:lecture, :subject => su, :owner => @teacher,
-                  :created_at => "2012-02-16".to_date)
+                  :created_at => @end)
 
       @space_statuses += 3.times.collect do
         Factory(:activity,
                 :statusable => s, :user => @teacher,
-                :created_at => "2012-02-16".to_date)
+                :created_at => @end)
       end
 
       @lecture_statuses += 3.times.collect do
         Factory(:activity,
                 :statusable => l, :user => @teacher,
-                :created_at => "2012-02-16".to_date)
+                :created_at => @end)
       end
 
       @ans += 2.times.collect do
+        acti = Factory(:activity, :statusable => l, :user => Factory(:user),
+               :created_at => @end)
         Factory(:answer, :statusable => l,
-                :in_response_to => l.statuses.first, :user => @teacher,
-                :created_at => "2012-02-16".to_date)
+                :in_response_to => acti, :user => @teacher,
+                :created_at => @end)
       end
 
       su.lectures << l
@@ -46,24 +51,24 @@ describe TeacherParticipation do
     su = Factory(:subject, :space => s,
                  :owner => @owner, :finalized => true)
     l = Factory(:lecture, :subject => su,
-                :owner => @teacher, :created_at => "2012-02-15".to_date)
+                :owner => @teacher, :created_at => @ini)
 
     3.times.collect do
       Factory(:activity,
               :statusable => s, :user => @teacher,
-              :created_at => "2012-02-15".to_date)
+              :created_at => @ini)
     end
 
     3.times.collect do
       Factory(:activity,
               :statusable => l, :user => @teacher,
-              :created_at => "2012-02-15".to_date)
+              :created_at => @ini)
     end
 
     2.times.collect do
       Factory(:answer, :statusable => l,
               :in_response_to => l.statuses.first, :user => @teacher,
-              :created_at => "2012-02-15".to_date)
+              :created_at => @ini)
     end
 
     su.lectures << l
@@ -147,8 +152,8 @@ describe TeacherParticipation do
 
   context "building" do
     it "queries by specified days" do
-      subject.start = "2012-02-15".to_date
-      subject.end = "2012-02-16".to_date
+      subject.start = @ini
+      subject.end = @end
       subject.generate!
 
       subject.lectures_created[0].should == 1


### PR DESCRIPTION
O erro consistia que as respostas eram filtradas apenas dos posts que o professor fez, a lógica foi mudada para considerar todos os posts do ambiente em questão
