### PR TITLE
Ajustes visualização de postagens 

### DIFF
--- a/app/views/statuses/_item.html.erb
+++ b/app/views/statuses/_item.html.erb
@@ -102,10 +102,10 @@
 
           <span class="status-info">
           <% if item.statusable_type.eql?('User') %>
-            <% unless item.statusable.eql?(current_user) %>
+            <% unless item.statusable.eql?(item.user) %>
               comentou no mural de <%= link_to item.statusable.display_name, show_mural_user_path(item.statusable) %>
             <% else %>
-              comentou no <%= link_to "seu próprio mural", show_mural_user_path(current_user) %>
+              comentou no <%= link_to "seu próprio mural", show_mural_user_path(item.user) %>
             <% end %>
           <% end %>
           </span>


### PR DESCRIPTION
Modifica a lógica de definição da mensagem de comentou no seu próprio mural.
Evitando a seguinte mensagem:

`Tarcisio comentou no mural de Tarcisio`

**Nota:** Os testes de integração já foram desenvolvidos e estão na branch `integration-tests`
