### PR TITLE
Trocando atributo do tooltip. Closes #775

### DIFF
--- a/public/javascripts/subject_participation.js
+++ b/public/javascripts/subject_participation.js
@@ -116,12 +116,16 @@ var subjectParticipationBullet = function () {
 
             // Atributo title para o tooltip
             d3.selectAll("rect")
-              .attr("title", "Total de alunos: " + data[0].ranges[0] +
+              .attr("alt", "Total de alunos: " + data[0].ranges[0] +
                 "<br/>Total de alunos que finalizaram o módulo: " + data[0].measures[0]);
 
             // Configuração default do tooltip
-            $(div).find('> svg > g > rect.range').tipTip({defaultPosition: "top"});
-            $(div).find('> svg > g > rect.measure').tipTip({defaultPosition: "top"});
+            $(div).find('> svg > g > rect.range').tipTip(
+                { defaultPosition: "top",
+                  attribute: "alt" });
+            $(div).find('> svg > g > rect.measure').tipTip(
+                { defaultPosition: "top",
+                  attribute: "alt" });
         }
       });
     };

--- a/public/javascripts/treemap.js
+++ b/public/javascripts/treemap.js
@@ -145,7 +145,7 @@ var StudentsTreemap = function () {
               .enter().append("svg:g")
               .attr("class", "cell")
               .attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; })
-              .attr("title", function (d) {
+              .attr("alt", function (d) {
                 var nota = d.grade !== null ? d.grade : "nenhum exercício realizado"
                 return "Nome: " + d.name + " " + d.last_name
                         + "</br>Comentários: " + d.activities
@@ -170,7 +170,8 @@ var StudentsTreemap = function () {
               .style("opacity", function(d) { d.w = this.getComputedTextLength(); return d.dx > d.w ? 1 : 0; });
 
             // Tooltip da célula
-            $(".cell").tipTip({defaultPosition: "left"});
+            $(".cell").tipTip( {defaultPosition: "left",
+                                attribute: "alt" });
           }
         })
       })


### PR DESCRIPTION
Fazendo com que o tooltip seja mapeado pelo atributo `alt` ao invés de `title` pois assim o Firefox não consegue mapear e acionar o tooltip default dele.
