### PR TITLE
Flexibilizado a regex de capturar o id do vídeo YouTube.

### DIFF
--- a/public/javascripts/ytpreview.jquery.js
+++ b/public/javascripts/ytpreview.jquery.js
@@ -12,8 +12,8 @@
           return this.urlRegex.test(value);
         },
         ytCode : function(value){
-          var result = value.match(/http\:\/\/www\.youtube\.com\/watch\?v=([A-Za-z0-9-_]{11})/);
-          return (result === null) ? false : result[1]
+          var result = value.match(/http\:\/\/(m|w{3})\.youtube\.com\/\S*v=([A-Za-z0-9-_]{11})/);
+          return (result === null) ? false : result[2]
         },
         ytEmbedURL : function(code){
           return "http://www.youtube.com/embed/" + code;


### PR DESCRIPTION
Permite que o id do vídeo do YouTube seja capturado em URLs do tipo: `http://[m|www].youtube.com/[qualquer-coisa]v=ID[qualquer-coisa]`.
