### PR TITLE
Insere a mensagem de erro no lugar correto. Fixes #855

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -109,7 +109,7 @@ jQuery(function(){
 
         if (email_val != confirmation_val) {
           $("#user_email_confirmation-error").remove();
-          $(this).after("<p id=\"user_email_confirmation-error\" class=\"errorMessageField\">Os e-mails digitados não são iguais.</p>");
+          $(this).next(".errors_on_field").append("<p id=\"user_email_confirmation-error\" class=\"errorMessageField\">Os e-mails digitados não são iguais.</p>");
 
         } else {
           $("#user_email_confirmation-error").remove();


### PR DESCRIPTION
Na tela de cadastro, insere a mensagem de erro para e-mail e confirmação diferentes no lugar correto. Ver #855.
