### PR TITLE
Aumentado a altura do FB's Like para não cortar os avatares. Fixes #961

### DIFF
--- a/app/views/base/site_index.html.erb
+++ b/app/views/base/site_index.html.erb
@@ -34,7 +34,7 @@
   <div class="staging grid_11">
     <h3 class="book-ad"><%= link_to "Professor, aprenda como educar com o Redu", "http://educarcom.redu.com.br" %></h3>
     <div class="facebook-like">
-      <iframe src="http://www.facebook.com/plugins/like.php?app_id=221316171245047&amp;href=http%3A%2F%2Fwww.facebook.com%2Fredesocialeducacional&amp;send=false&amp;layout=standard&amp;width=280&amp;show_faces=true&amp;action=like&amp;colorscheme=light&amp;font&amp;height=80" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:280px; height:80px;" allowTransparency="true"></iframe>
+      <iframe src="http://www.facebook.com/plugins/like.php?app_id=221316171245047&amp;href=http%3A%2F%2Fwww.facebook.com%2Fredesocialeducacional&amp;send=false&amp;layout=standard&amp;width=280&amp;show_faces=true&amp;action=like&amp;colorscheme=light&amp;font&amp;height=80" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:280px; height:100px;" allowTransparency="true"></iframe>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Aumentei a altura do botão de Like do Facebook para não cortar a segunda linha de avatares. Ver issue #961.
