### PR TITLE
closes #1096

### DIFF
--- a/public/javascripts/landing.js
+++ b/public/javascripts/landing.js
@@ -41,4 +41,8 @@ $(function() {
 
     $('html, body').animate({scrollTop: (offset - height)}, 500);
   });
+
+  $('.facebook-sign-in-button, .header-sign-in-recover').click( function(e) {
+    e.stopPropagation();
+  });
 });


### PR DESCRIPTION
Foi necessária a adição de um Script para evitar que a janela modal fechasse ao clicar em um elemento fora de formulário.
