### PR TITLE
Botão de Nova Mensagem mal posicionado

### DIFF
--- a/public/stylesheets/scss/home/_messages.scss
+++ b/public/stylesheets/scss/home/_messages.scss
@@ -16,6 +16,4 @@
 
 .message-list-subject { width: 310px; }
 
-.button-new-message {
-	float: right;
-}
+#button-new-message { float: right; }


### PR DESCRIPTION
Transforma .button-new-message em id. Closes #1157

Na verdade a issue já tinha sido resolvida, mas a correção deveria ter sido feita neste arquivo Scss.
