### PR TITLE
Link da Central de Ajuda no fim do tour não abre em aba separada 

### DIFF
--- a/app/views/users/_explore_redu.html.erb
+++ b/app/views/users/_explore_redu.html.erb
@@ -41,7 +41,7 @@
       <% unless user.settings.visited?("basic-guide") %>
         <li>
           <%= link_to "Visite o Guia Básico da Central de Ajuda.",
-            Redu::Application.config.redu_services[:help_center][:url] + "guia-basico" , :class => "icon-help-central-lightblue_16_18-before", "data-tour" => "basic-guide" %>
+            Redu::Application.config.redu_services[:help_center][:url] + "guia-basico" , :class => "icon-help-central-lightblue_16_18-before", "data-tour" => "basic-guide", :target => "_blank" %>
         </li>
       <% end %>
     </ul>

--- a/app/views/users/_help_center.html.erb
+++ b/app/views/users/_help_center.html.erb
@@ -4,5 +4,5 @@
 <div class="right-sidebar-area">
   <h6 class="right-sidebar-area-title">Saiba mais</h6>
   <div class="nav-local-separator"></div>
-  <p class="legend">Na <%= link_to "Central de Ajuda", Redu::Application.config.redu_services[:help_center][:url], :class => "link-secondary", :title => "Central de Ajuda" %> você pode ler mais informações sobre o que é possível fazer com o Redu e ter suas dúvidas respondidas.</p>
+  <p class="legend">Na <%= link_to "Central de Ajuda", Redu::Application.config.redu_services[:help_center][:url], :class => "link-secondary", :title => "Central de Ajuda", :target => "_blank" %> você pode ler mais informações sobre o que é possível fazer com o Redu e ter suas dúvidas respondidas.</p>
 </div>

--- a/app/views/users/_tour.html.erb
+++ b/app/views/users/_tour.html.erb
@@ -207,7 +207,7 @@
       <h4>Ainda restam dúvidas?</h4>
     </div>
     <div class="modal-body">
-      <p>Estamos dispostos a atendê-lo sempre que precisar. Caso este Tour não tenha contemplado suas dúvidas, acesse a <%= link_to "Central de Ajuda", Redu::Application.config.redu_services[:help_center][:url], :title => "Central de Ajuda" %> e busque por um tópico de sua preferência.</p>
+      <p>Estamos dispostos a atendê-lo sempre que precisar. Caso este Tour não tenha contemplado suas dúvidas, acesse a <%= link_to "Central de Ajuda", Redu::Application.config.redu_services[:help_center][:url], :title => "Central de Ajuda", :target => "_blank" %> e busque por um tópico de sua preferência.</p>
     </div>
     <div class="modal-footer">
       <p class="legend">14 de 14</p>


### PR DESCRIPTION
Altera os links para Central de Ajuda para abrir em uma nova janela. Closes #1171
