### PR TITLE
Cabeçalho da página de Ambientes com altura errada

### DIFF
--- a/app/views/users/environments/index.html.erb
+++ b/app/views/users/environments/index.html.erb
@@ -7,16 +7,18 @@
     <%= render :partial => "users/environments/breadcrumb",
        :locals => { :user => @user } %>
     <div class="content-body">
-      <ul class="content-section header-breadcrumb">
-        <li class="header-breadcrumb-item">
-          <%= link_to user_environments_path(@user),
-            :class => "header-bradcrumb-link icon-environment-round-gray_32_34-before",
-            :title => "Ambientes que Participo" do %>
-            Ambientes que Participo <%= content_tag(:span, parentize(@total_environments),
-              :class => "header-breadcrumb-item-light") %>
-          <% end %>
-        </li>
-      </ul>
+      <div class="content-section">
+        <ul class="header-breadcrumb">
+          <li class="header-breadcrumb-item">
+            <%= link_to user_environments_path(@user),
+              :class => "header-bradcrumb-link icon-environment-round-gray_32_34-before",
+              :title => "Ambientes que Participo" do %>
+              Ambientes que Participo <%= content_tag(:span, parentize(@total_environments),
+                :class => "header-breadcrumb-item-light") %>
+            <% end %>
+          </li>
+        </ul>
+      </div>
       <% if @environments.empty? %>
         <hr class="list-separator">
         <div class="empty-environment">

--- a/public/stylesheets/bootstrap-redu.css
+++ b/public/stylesheets/bootstrap-redu.css
@@ -5689,6 +5689,7 @@ a.icon-teacher-gray_16_18-before:hover:before, .icon-teacher-gray_16_18-before:h
 .header-breadcrumb {
   list-style: none;
   margin: 0;
+  padding: 7px 0 6px;
   display: inline-block;
 }
 .header-breadcrumb:before, .header-breadcrumb:after {
@@ -5700,10 +5701,10 @@ a.icon-teacher-gray_16_18-before:hover:before, .icon-teacher-gray_16_18-before:h
 }
 
 .header-breadcrumb-item {
+  height: 21px;
   font: 500 21px/21px museo-sans, "Helvetica Neue", Arial, sans-serif;
   letter-spacing: -1px;
   float: left;
-  margin-top: 7px;
 }
 .header-breadcrumb-item +
 .header-breadcrumb-item:before {
@@ -5716,10 +5717,12 @@ a.icon-teacher-gray_16_18-before:hover:before, .icon-teacher-gray_16_18-before:h
 
 .header-breadcrumb-item-light {
   font-weight: 100;
+  display: inherit;
 }
 
 .header-bradcrumb-link {
   font-weight: 300;
+  height: inherit;
 }
 .header-breadcrumb .header-bradcrumb-link {
   color: #b3b3b3;


### PR DESCRIPTION
Atualiza o bootstrap CSS com o fix para a altura dos cabeçalhos do início. Closes #1181
