### PR TITLE
Colocar link da Central de Ajuda no footer novo (landing)

### DIFF
--- a/app/views/landing/_management_n_support.html.erb
+++ b/app/views/landing/_management_n_support.html.erb
@@ -13,7 +13,9 @@
         <div class="offset2 span3">
           <h3 class="landing-navigation-subtitle">Suporte</h3>
           <h4>Sinta-se apoiado!</h4>
-          <p>Conte com nosso atendimento sempre que precisar, através de nossa plataforma e e-mail.</p>
+          <p>Conte com nosso atendimento e use a <%= link_to "Central de Ajuda",
+              Redu::Application.config.redu_services[:help_center][:url],
+              :title => "Central de Ajuda", :target => "_blank" %> para tirar suas dúvidas.</p>
         </div>
       </div>
     </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
       <div class="span4">
         <div class="footer-logo-wrapper">
           <%= link_to "http://tech.redu.com.br/",
-              :class => "footer-logo-link" do %>
+            :class => "footer-logo-link" do %>
               <h1 class="footer-logo-img sprite-logo-redu-tech-footer text-replacement">Redu Educational Technologies</h1>
           <% end %>
           <span class="footer-cnpj">CNPJ: 12.359.885 / 0001-07</span>
@@ -14,36 +14,36 @@
         <ul class="footer-navigation">
           <li>
             <%= link_to "Sobre o Redu",
-                home_path(:anchor => ""),
-                :title => "Sobre o Redu"
+              home_path(:anchor => ""),
+              :title => "Sobre o Redu"
             %>
           </li>
           <li>
             <%= link_to "Segmentos",
-                home_path(:anchor => "segmentos"),
-                :title => "Segmentos",
-                :class => "landing-scroll"
+              home_path(:anchor => "segmentos"),
+              :title => "Segmentos",
+              :class => "landing-scroll"
             %>
           </li>
           <li>
             <%= link_to "Vantagens",
-                home_path(:anchor => "vantagens"),
-                :title => "Vantagens",
-                :class => "landing-scroll"
+              home_path(:anchor => "vantagens"),
+              :title => "Vantagens",
+              :class => "landing-scroll"
             %>
           </li>
           <li>
             <%= link_to "Funcionalidades",
-                home_path(:anchor => "funcionalidades"),
-                :title => "Funcionalidades",
-                :class => "landing-scroll"
+              home_path(:anchor => "funcionalidades"),
+              :title => "Funcionalidades",
+              :class => "landing-scroll"
             %>
           </li>
           <li>
             <%= link_to "Planos",
-                home_path(:anchor => "planos"),
-                :title => "Planos",
-                :class => "landing-scroll"
+              home_path(:anchor => "planos"),
+              :title => "Planos",
+              :class => "landing-scroll"
             %>
           </li>
         </ul>
@@ -51,29 +51,34 @@
       <div class="span3">
         <ul class="footer-navigation">
           <li>
+            <%= link_to "Central de Ajuda",
+              Redu::Application.config.redu_services[:help_center][:url],
+              :title => "Central de Ajuda", :target => "_blank" %>
+          </li>
+          <li>
             <%= link_to "Blog",
-                "http://blog.redu.com.br/",
-                :title => "Blog"
+              "http://blog.redu.com.br/",
+              :title => "Blog"
             %>
           </li>
           <li>
             <%= link_to "Desenvolvedores",
-                "http://developers.redu.com.br/",
-                :title => "Desenvolvedores"
+              "http://developers.redu.com.br/",
+              :title => "Desenvolvedores"
             %>
           </li>
           <li>
             <%= link_to "Política de Privacidade",
-                "#modal-privacy-policy",
-                :title => "Política de Privacidade",
-                "data-toggle" => "modal"
+              "#modal-privacy-policy",
+              :title => "Política de Privacidade",
+              "data-toggle" => "modal"
             %>
           </li>
           <li>
             <%= link_to "Termos de Uso",
-                "#modal-tos",
-                :title => "Termos de Uso",
-                "data-toggle" => "modal"
+              "#modal-tos",
+              :title => "Termos de Uso",
+              "data-toggle" => "modal"
             %>
           </li>
         </ul>
@@ -85,8 +90,13 @@
           <span class="legend">Siga-nos na web</span>
         </div>
         <div class="footer-social-networks">
-          <%= link_to "Facebook", "https://www.facebook.com/redesocialeducacional", :class => "footer-social-network sprite-social-facebook text-replacement", :title => "Facebook" %>
-          <%= link_to "Twitter", "http://twitter.com/redu_ead", :class => "footer-social-network sprite-social-twitter text-replacement", :title => "Twitter" %>
+          <%= link_to "Facebook",
+            "https://www.facebook.com/redesocialeducacional",
+            :class => "footer-social-network sprite-social-facebook text-replacement",
+            :title => "Facebook" %>
+          <%= link_to "Twitter", "http://twitter.com/redu_ead",
+            :class => "footer-social-network sprite-social-twitter text-replacement",
+            :title => "Twitter" %>
         </div>
       </div>
       <div class="span3">
@@ -95,9 +105,9 @@
             <div class="span2">
               <h3>
                 <%= link_to "Fale Conosco",
-                      contact_path,
-                      :title => "Fale Conosco",
-                      :class => "link-target"
+                  contact_path,
+                  :title => "Fale Conosco",
+                  :class => "link-target"
                 %>
               </h3>
               <p class="legend">Dúvidas? Nosso suporte online pode lhe ajudar</p>


### PR DESCRIPTION
Aproveitei pra consertar as identações e falei com Sérgio para colocar outro link na parte de Suporte da landing.

Adiciona o link para Central de Ajuda no footer e landing. Closes #1195

![download](https://f.cloud.github.com/assets/381395/11253/cc298ca2-4548-11e2-971b-8f7bbf72d164.png)

![download 1 ](https://f.cloud.github.com/assets/381395/11254/ce2f5fa4-4548-11e2-81ef-9ae5ce327007.png)
