### PR TITLE
Botão de mostrar as disciplinas em "Ambientes" não funcionam no retorno do endless

### DIFF
--- a/app/views/users/environments/_course.html.erb
+++ b/app/views/users/environments/_course.html.erb
@@ -15,7 +15,7 @@
         <h5>
           <%= link_to course.name, environment_course_path(environment, course), :title => course.name, :class => "list-mix-title" %>
         </h5>
-        <span class="legend"><%= course.spaces.length %> disciplinas</span>
+        <span class="legend"><%= pluralize(course.spaces.length, "disciplina") %></span>
       </div>
       <% unless course.spaces.empty? %>
         <ul class="list-mix-body list-space-mini">

--- a/public/javascripts/bootstrap-redu.js
+++ b/public/javascripts/bootstrap-redu.js
@@ -1477,57 +1477,41 @@ $(function() {
 
   var methods = {
 
-    toggleDropdown: function(listMixItem, openClass, listMixHeaderLegend, listMixInfoClass, listMixBody) {
-      if (listMixItem.hasClass(openClass)) {
-        listMixItem.removeClass(openClass)
-        listMixHeaderLegend.css("visibility", "visible")
-        listMixInfoClass.show()
+    // Expande/colapsa o dropdown.
+    // Esconde a legenda, notificações e mostra a lista de disciplinas.
+    toggleDropdown: function(options) {
+      var settings = $.extend({}, $.fn.reduList.defaults, options)
+
+      var $dropdown = $(this)
+        , $listMixItem = $dropdown.closest("." + settings.classes.listMixItem)
+        , $listMixHeaderLegend = $listMixItem.find("." +
+          settings.classes.listMixHeaderLegend)
+        , $listMixBody = $listMixItem.find("." + settings.classes.listMixBody)
+        , $listMixInfoClass = $listMixItem.find("." +
+          settings.classes.listMixInfo)
+
+      if ($listMixItem.hasClass(settings.classes.openState)) {
+        $listMixHeaderLegend.css("visibility", "visible")
       } else {
-        listMixItem.addClass(openClass)
-        listMixHeaderLegend.css("visibility", "hidden")
-        listMixInfoClass.hide()
+        $listMixHeaderLegend.css("visibility", "hidden")
       }
 
-      listMixBody.toggle(150, "swing");
-    },
+      $listMixInfoClass.toggle()
+      $listMixItem.toggleClass(settings.classes.openState)
+      $listMixBody.toggle(150, "swing")
 
-    listMix: function(options) {
-      var settings = $.extend({
-          "buttonDrownClass": "button-dropdown:not(.button-disabled)",
-          "openClass": "open",
-          "listMixBodyClass": "list-mix-body",
-          "listMixHeaderLegend": "list-mix-header .legend",
-          "listMixInfoClass": "list-mix-info"
-        }, options)
-
-      return this.each(function() {
-        var listMix = $(this),
-            listMixItems = listMix.children()
-
-        listMixItems.each(function() {
-          var listMixItem = $(this),
-              buttonDropdown = listMixItem.find("." + settings.buttonDrownClass),
-              listMixBody = listMixItem.find("." + settings.listMixBodyClass),
-              listMixHeaderLegend = listMixItem.find("." + settings.listMixHeaderLegend),
-              listMixInfoClass = listMixItem.find("." + settings.listMixInfoClass),
-              listMixHeader = listMixItem.find(".list-mix-header")
-
-          buttonDropdown.on("click", function() {
-            methods.toggleDropdown(listMixItem, settings.openClass, listMixHeaderLegend, listMixInfoClass, listMixBody)
-          })
-        })
-      })
+      return $dropdown
     },
 
     init: function(options) {
 
     }
-
   }
 
   $.fn.reduList = function(method) {
     if (methods[method]) {
-      return methods[method].apply(this, Array.prototype.slice.call(arguments, 1))
+      return methods[method].apply(this, Array.prototype.slice.call(arguments,
+        1))
     } else if (typeof method === "object" || !method) {
       return methods.init.apply(this, arguments)
     } else {
@@ -1535,11 +1519,24 @@ $(function() {
     }
   }
 
-}) (window.jQuery)
+  $.fn.reduList.defaults = {
+    classes: {
+      listMixItem: "list-mix-item"
+    , listMixHeaderLegend: "list-mix-header .legend"
+    , listMixBody: "list-mix-body"
+    , listMixInfo: "list-mix-info"
+    , openState: "open"
+    }
+  }
 
-$(function() {
-  $(".list-mix").reduList("listMix")
-})
+  $(function() {
+    $(document).on("click", ".list-mix .button-dropdown:not(.button-disabled)",
+      function(e) {
+      $(this).reduList("toggleDropdown")
+    })
+  })
+
+}) (window.jQuery)
 $(function() {
   //Desabilita href dos links com estilo de botão, quando no estado desabilidado.
   $(".button-disabled").live("click", function(e) {


### PR DESCRIPTION
Atualiza o bootstrap JS com o fix do botão de dropdown da lista de ambientes-cursos-disciplinas para itens adicionados dinamicamente. Closes #1198

Aproveitei também pra colocar o `pluralize` na contagem de disciplinas da lista.
