### PR TITLE
Box do Explore azul fecha quando não há link

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -19,7 +19,7 @@ module UsersHelper
 
   def explored_all_tips?(user)
     user.settings.visited?(edit_user_path(user),new_user_friendship_path(user),
-                  new_user_message_path(user), courses_index_path,
+                  user_messages_path(user), courses_index_path,
                   teach_index_path, "basic-guide", "tour-1")
   end
 


### PR DESCRIPTION
O problema é que ele estava avaliando uma url errada
