### PR TITLE
closes #1031

### DIFF
--- a/public/stylesheets/wall.css
+++ b/public/stylesheets/wall.css
@@ -272,6 +272,10 @@
   cursor: pointer;
 }
 
+.icon-request-help-orange_64_66-after + .status-log .close {
+  clear: both;
+}
+
 .create-status .post-resource .source-site,
 #statuses .status .post-resource .source-site {
   color: rgb(204, 204, 204);


### PR DESCRIPTION
Conserta o ícone de excluir, que não estava pegando. Vou conversar com @andredm a respeito do erro do nome aparecer por trás do boneco pois se trata de uma tarefinha complicada.
