### PR TITLE
Fix lógica no ability dos ambientes bloqueados para redu_admin

### DIFF
--- a/app/abilites/ability.rb
+++ b/app/abilites/ability.rb
@@ -88,9 +88,11 @@ class Ability
         user.can_read? object
       end
 
-      # Nenhum ambiente bloqueado pode ser visto, a não ser pelo redu_admin
-      cannot [:manage, :read], [Environment, Course, Space, Subject, Lecture],
-        :blocked => true && !is_admin
+      unless is_admin
+        # Nenhum ambiente bloqueado pode ser visto, a não ser pelo redu_admin
+        cannot [:manage, :read], [Environment, Course, Space, Subject, Lecture],
+          :blocked => true
+      end
 
       can :create, Environment
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -728,6 +728,15 @@ describe Ability do
           @space = Factory(:space, :owner => @env_admin,
                           :course => @course)
         end
+
+        it "read a space" do
+          @ability.should be_able_to(:read, @space)
+        end
+
+        it "manage a space" do
+          @ability.should be_able_to(:manage, @space)
+        end
+
         it "creates a space" do
           space = Factory(:space, :owner => @redu_admin,
                           :course => @course)


### PR DESCRIPTION
Recloses #1131

Adiciona um teste para redu_admin ver e administrar um Space nã bloqueado, para cobrir o caso de um ambiente não bloqueado.
