### PR TITLE
Insere regra ao ícone que permite excluir pedido de ajuda

### DIFF
--- a/app/views/statuses/_item.html.erb
+++ b/app/views/statuses/_item.html.erb
@@ -29,7 +29,7 @@
                 status_path(item),
                 :method => :delete,
                 :remote => true,
-                :class => 'close icon-small icon-close-gray_16_16 replacement',
+                :class => 'close icon-small icon-close-gray_16_16 replacement remove-help-request',
                 :confirm => 'Ao remover o pedido de ajuda, as respostas também serão apagadas. Deseja removê-lo?'%>
           <% end %>
             <%= render :partial => 'statuses/timeago', :locals => { :item => item } %>

--- a/public/stylesheets/wall.css
+++ b/public/stylesheets/wall.css
@@ -124,6 +124,10 @@
   width: 16px;
 }
 
+.statuses .remove-help-request {
+  position: relative;
+}
+
 .statuses .status-message {
   line-height: 18px;
   overflow: hidden;


### PR DESCRIPTION
O ícone ficava abaixo do "suvaco" do ícone maior, porém numa visão geral era envolvido pela mesma fazendo com que perdesse a funcionalidade de ícone. Adicionei a regra "position: relative" para que mesmo envolvido pela mesma o ícone tivesse o comportamento desejado, um link.
 Closes #1393
