### PR TITLE
Adiciona margin-top para a ação de convidar/aceitar membro.

### DIFF
--- a/public/stylesheets/new-style.css
+++ b/public/stylesheets/new-style.css
@@ -1959,6 +1959,10 @@ body {
   padding: 2px 0 2px 25px;
 }
 
+#content .incomplete-profile + .new-friendship {
+  margin-top: 10px;
+}
+
 #content .actions {
   margin-left: 10px;
 }


### PR DESCRIPTION
Esse bug só é perceptível se o usuário for um administrador. Então, uma margem top foi adicionada à ação adicionar/aceitar membro só quando tal ação estiver abaixo da informação da porcentagem preenchida do perfil, o que limita a acontecer apenas para administradores. Closes #1385
